### PR TITLE
noter.Editor: Play nice with the system keymap, regardless of what it is.

### DIFF
--- a/editor_test.go
+++ b/editor_test.go
@@ -3,26 +3,7 @@ package noter
 import (
 	"reflect"
 	"testing"
-
-	"github.com/hajimehoshi/ebiten/v2"
 )
-
-func TestKeyToRune(t *testing.T) {
-	r, printable := KeyToRune(ebiten.KeyA, true)
-	if r != 'A' && printable {
-		t.Fatalf(`Expected 'A' and printable: true, got: %v %v`, r, printable)
-	}
-
-	r, printable = KeyToRune(ebiten.KeyB, false)
-	if r != 'b' && printable {
-		t.Fatalf(`Expected 'b' and printable: true, got: %v %v`, r, printable)
-	}
-
-	r, printable = KeyToRune(ebiten.KeyEnter, false)
-	if r != 0 && !printable {
-		t.Fatalf(`Expected '0' and printable: false, got: %v %v`, r, printable)
-	}
-}
 
 func TestGetLineNumber(t *testing.T) {
 	line1 := &editorLine{}


### PR DESCRIPTION
Use the ebiten.KeyName() and ebiten.AppendInputChars() to properly respect the input keymap.

Tested on Linux with US, Dvorak, and French (Azerty) keymaps.